### PR TITLE
20240609:Adapt to the latest Raindrop API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,4 @@
 # Unofficial Raindrop.io API client
-## Work in progress
-
-[![Actions Status](https://github.com/kattaris/raindrop-io-api-client/workflows/CI/badge.svg)](https://github.com/kattaris/raindrop-io-api-client/actions)
-[![Coverage Status](https://codecov.io/github/kattaris/raindrop-io-api-client/coverage.svg?branch=master)](https://codecov.io/gh/kattaris/raindrop-io-api-client)
-[![Releases](https://img.shields.io/github/v/release/kattaris/raindrop-io-api-client.svg?include_prereleases&style=flat-square)](https://github.com/kattaris/raindrop-io-api-client/releases)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ### Example usage:
 
@@ -13,8 +7,8 @@ package main
 
 import (
 	"fmt"
-	"github.com/kattaris/errhand"
-	"github.com/kattaris/raindrop-io-api-client/pkg/raindrop"
+	"github.com/andrewrong/errhand"
+	"github.com/andrewrong/raindrop-io-api-client/pkg/raindrop"
 	"net/http"
 	"net/url"
 	"os"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kattaris/raindrop-io-api-client
+module github.com/andrewrong/raindrop-io-api-client
 
 go 1.17
 


### PR DESCRIPTION
 - Remove work in progress section and related badges from README.md.
 - Update repository references in import paths from 'kattaris' to 'andrewrong'.
 - Change module path in go.mod to reflect new repository location.