### PR TITLE
20240609: support search param

### DIFF
--- a/pkg/raindrop/client_test.go
+++ b/pkg/raindrop/client_test.go
@@ -97,7 +97,11 @@ func Test_GetRaindrops(t *testing.T) {
 	// Then
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	actual, err := sut.GetRaindrops("access-token", "1", 50, ctx)
+	param := &SearchRdParams{
+		Search:   "1",
+		PageSize: 50,
+	}
+	actual, err := sut.GetRaindrops("access-token", param, ctx)
 	if err != nil {
 		t.Errorf("error: %v", err)
 	}


### PR DESCRIPTION
 This commit introduces a new structure, SearchRdParams, which encapsulates all search-related parameters for the GetRaindrops function. It replaces the
 previous method of passing collectionID and perpage directly as arguments. The SearchRdParams struct includes fields for CollectionId, Search, Sort, Page, a
 PageSize, and a method AddToQuery to add these parameters to the query string.

 Additionally, three new constants have been defined to represent special collection IDs: ALL_COLLECTION_ID, UNSORT_COLLECTION_ID, and TRASH_COLLECTION_ID.
 These constants improve code readability and maintainability by providing meaningful names for these magic numbers.

 The client_test.go has been updated to reflect these changes by creating a SearchRdParams instance and passing it to the GetRaindrops function.

 Overall, this commit enhances the flexibility and clarity of the GetRaindrops API call.